### PR TITLE
Change Dockerfile to use latest dart image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.0
+FROM google/dart:latest
 
 COPY ./ ./
 


### PR DESCRIPTION
I generated an application with `angel init`

When running the application in a docker container, I get the error.
`file:///root/.pub-cache/hosted/pub.dartlang.org/angel_configuration-2.1.0/lib/angel_configuration.dart:62:1: Error: 'Future' expects 0 type arguments.`
This is due to the fact that *angel_configuration.dart* does not import 'dart:async'.
This works when using the latest dart version.
[see](https://github.com/dart-lang/sdk/issues/26162)
[see](https://github.com/dart-lang/sdk/issues/34384)
[see](https://github.com/dart-lang/sdk/issues/34237)