### PR TITLE
Update quiver hashcode dependency

### DIFF
--- a/packages/auth/lib/src/configuration.dart
+++ b/packages/auth/lib/src/configuration.dart
@@ -1,7 +1,7 @@
 import 'package:charcode/ascii.dart';
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
-import 'package:quiver_hashcode/hashcode.dart';
+import 'package:quiver/core.dart';
 
 /// A common class containing parsing and validation logic for third-party authentication configuration.
 class ExternalAuthOptions {

--- a/packages/auth/pubspec.yaml
+++ b/packages/auth/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   crypto: ^2.0.0
   http_parser: ^3.0.0
   meta: ^1.0.0
-  quiver_hashcode: ^2.0.0
+  quiver: ^2.0.0
 dev_dependencies:
   http: ^0.12.0
   io: ^0.3.2

--- a/packages/framework/lib/src/core/service.dart
+++ b/packages/framework/lib/src/core/service.dart
@@ -3,7 +3,7 @@ library angel_framework.http.service;
 import 'dart:async';
 import 'package:angel_http_exception/angel_http_exception.dart';
 import 'package:merge_map/merge_map.dart';
-import 'package:quiver_hashcode/hashcode.dart';
+import 'package:quiver/core.dart';
 import '../util.dart';
 import 'anonymous_service.dart';
 import 'hooked_service.dart' show HookedService;

--- a/packages/framework/pubspec.yaml
+++ b/packages/framework/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   mock_request: ^1.0.0
   path: ^1.0.0
   # pedantic: ^1.0.0
-  quiver_hashcode: ^2.0.0
+  quiver: ^2.0.0
   recase: ^2.0.0
   stack_trace: ^1.0.0
   string_scanner: ^1.0.0

--- a/packages/serialize/angel_serialize/lib/angel_serialize.dart
+++ b/packages/serialize/angel_serialize/lib/angel_serialize.dart
@@ -2,7 +2,7 @@ export 'dart:convert' show json, Codec, Converter;
 export 'package:angel_model/angel_model.dart';
 export 'package:collection/collection.dart';
 export 'package:meta/meta.dart' show required, Required;
-export 'package:quiver_hashcode/hashcode.dart' show hashObjects;
+export 'package:quiver/core.dart' show hashObjects;
 
 /// Excludes a field from being excluded.
 class Exclude extends SerializableField {

--- a/packages/serialize/angel_serialize/pubspec.yaml
+++ b/packages/serialize/angel_serialize/pubspec.yaml
@@ -10,4 +10,4 @@ dependencies:
   collection: ^1.0.0
   meta: ^1.0.0
   pedantic: ^1.0.0
-  quiver_hashcode: ^2.0.0
+  quiver: ^2.0.0


### PR DESCRIPTION
Development on the quiver_* subpackages has been discontinued in favour
of the main quiver package at https://github.com/~/quiver-dart. The
code itself is identical, but is more actively maintained.

This migrates to version 2.0.0 of quiver since version 3.0.0 has been
migrated to null-safety, which requires Dart SDK 2.12.0 or Flutter
2.0.0.